### PR TITLE
Add MCP server library and codegen tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ __debug_bin*
 .history/
 
 
+bin/

--- a/cmd/mcpgen/generate.go
+++ b/cmd/mcpgen/generate.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/DIMO-Network/server-garage/pkg/mcpserver"
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// parseSchema reads .graphqls files, finds Query fields annotated with @mcpTool,
+// and returns a slice of ToolDefinition.
+func parseSchema(schemaPaths []string, prefix string) ([]mcpserver.ToolDefinition, error) {
+	var sources []*ast.Source
+	for _, p := range schemaPaths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", p, err)
+		}
+		sources = append(sources, &ast.Source{
+			Name:  filepath.Base(p),
+			Input: string(data),
+		})
+	}
+
+	schema, gqlErr := gqlparser.LoadSchema(sources...)
+	if gqlErr != nil {
+		return nil, fmt.Errorf("parsing schema: %s", gqlErr.Error())
+	}
+
+	queryType := schema.Query
+	if queryType == nil {
+		return nil, fmt.Errorf("no Query type found in schema")
+	}
+
+	var tools []mcpserver.ToolDefinition
+	for _, field := range queryType.Fields {
+		dir := field.Directives.ForName("mcpTool")
+		if dir == nil {
+			continue
+		}
+
+		nameArg := dir.Arguments.ForName("name")
+		descArg := dir.Arguments.ForName("description")
+		selArg := dir.Arguments.ForName("selection")
+		if nameArg == nil || descArg == nil || selArg == nil {
+			continue
+		}
+
+		toolName := nameArg.Value.Raw
+		if prefix != "" {
+			toolName = prefix + "_" + toolName
+		}
+		description := descArg.Value.Raw
+		selection := selArg.Value.Raw
+
+		// Validate selection against return type
+		if selection != "" {
+			returnType := schema.Types[field.Type.Name()]
+			if returnType == nil {
+				return nil, fmt.Errorf("return type %s not found", field.Type.Name())
+			}
+			if err := validateSelection(selection, returnType, schema); err != nil {
+				return nil, fmt.Errorf("field %s: %w", field.Name, err)
+			}
+		}
+
+		// Build args
+		var args []mcpserver.ArgDefinition
+		for _, a := range field.Arguments {
+			argDesc := a.Description
+			if argDesc == "" {
+				argDesc = a.Name + " argument"
+			}
+			args = append(args, mcpserver.ArgDefinition{
+				Name:        a.Name,
+				Type:        mapGraphQLType(a.Type, schema),
+				Description: argDesc,
+				Required:    a.Type.NonNull,
+			})
+		}
+
+		// Build query string
+		query := buildQueryString(field, selection)
+
+		tools = append(tools, mcpserver.ToolDefinition{
+			Name:        toolName,
+			Description: description,
+			Args:        args,
+			Query:       query,
+		})
+	}
+
+	return tools, nil
+}
+
+// buildQueryString constructs a GraphQL query string from a field definition.
+func buildQueryString(field *ast.FieldDefinition, selection string) string {
+	var sb strings.Builder
+
+	// Build variable declarations
+	if len(field.Arguments) > 0 {
+		sb.WriteString("query(")
+		for i, a := range field.Arguments {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString("$")
+			sb.WriteString(a.Name)
+			sb.WriteString(": ")
+			sb.WriteString(a.Type.String())
+		}
+		sb.WriteString(") { ")
+	} else {
+		sb.WriteString("{ ")
+	}
+
+	// Build field call
+	sb.WriteString(field.Name)
+	if len(field.Arguments) > 0 {
+		sb.WriteString("(")
+		for i, a := range field.Arguments {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(a.Name)
+			sb.WriteString(": $")
+			sb.WriteString(a.Name)
+		}
+		sb.WriteString(")")
+	}
+
+	// Add selection set
+	if selection != "" {
+		sb.WriteString(" { ")
+		sb.WriteString(selection)
+		sb.WriteString(" }")
+	}
+
+	sb.WriteString(" }")
+	return sb.String()
+}
+
+// validateSelection checks that top-level field names in the selection exist on the type.
+func validateSelection(selection string, typeDef *ast.Definition, schema *ast.Schema) error {
+	fields := extractTopLevelFields(selection)
+	for _, f := range fields {
+		found := false
+		for _, tf := range typeDef.Fields {
+			if tf.Name == f {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("field %q not found on type %s", f, typeDef.Name)
+		}
+	}
+	return nil
+}
+
+// extractTopLevelFields extracts top-level field names from a selection string,
+// skipping nested { } blocks.
+func extractTopLevelFields(selection string) []string {
+	var fields []string
+	depth := 0
+	tokens := strings.Fields(selection)
+	for _, tok := range tokens {
+		if tok == "{" {
+			depth++
+			continue
+		}
+		if tok == "}" {
+			depth--
+			continue
+		}
+		if depth == 0 {
+			// Strip any trailing { that might be attached
+			clean := strings.TrimSuffix(tok, "{")
+			if clean != "" {
+				fields = append(fields, clean)
+			}
+		}
+	}
+	return fields
+}
+
+// mapGraphQLType converts a GraphQL type to a JSON Schema type string.
+// Custom scalars (Time, Address, etc.) and enums are mapped to "string"
+// since they serialize as strings in JSON.
+func mapGraphQLType(t *ast.Type, schema *ast.Schema) string {
+	name := t.Name()
+	switch name {
+	case "Int":
+		return "integer"
+	case "Float":
+		return "number"
+	case "Boolean":
+		return "boolean"
+	case "String", "ID":
+		return "string"
+	default:
+		if def, ok := schema.Types[name]; ok {
+			if def.Kind == ast.Scalar || def.Kind == ast.Enum {
+				return "string"
+			}
+		}
+		return "object"
+	}
+}
+
+var goFileTemplate = template.Must(template.New("mcptools").Parse(`// Code generated by mcpgen. DO NOT EDIT.
+package {{.Package}}
+
+import "github.com/DIMO-Network/server-garage/pkg/mcpserver"
+
+var MCPTools = []mcpserver.ToolDefinition{
+{{- range .Tools}}
+	{
+		Name:        {{printf "%q" .Name}},
+		Description: {{printf "%q" .Description}},
+		Args: []mcpserver.ArgDefinition{
+		{{- range .Args}}
+			{Name: {{printf "%q" .Name}}, Type: {{printf "%q" .Type}}, Description: {{printf "%q" .Description}}, Required: {{.Required}}},
+		{{- end}}
+		},
+		Query: {{printf "%q" .Query}},
+	},
+{{- end}}
+}
+`))
+
+type templateData struct {
+	Package string
+	Tools   []mcpserver.ToolDefinition
+}
+
+// generateGoFile renders a Go source file containing the tool definitions.
+func generateGoFile(pkg string, tools []mcpserver.ToolDefinition) (string, error) {
+	var sb strings.Builder
+	if err := goFileTemplate.Execute(&sb, templateData{
+		Package: pkg,
+		Tools:   tools,
+	}); err != nil {
+		return "", fmt.Errorf("executing template: %w", err)
+	}
+	return sb.String(), nil
+}

--- a/cmd/mcpgen/generate_test.go
+++ b/cmd/mcpgen/generate_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDirective(t *testing.T) {
+	tools, err := parseSchema([]string{"testdata/basic.graphqls"}, "")
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+
+	// hello tool
+	assert.Equal(t, "hello", tools[0].Name)
+	assert.Equal(t, "Say hello to someone", tools[0].Description)
+	require.Len(t, tools[0].Args, 1)
+	assert.Equal(t, "name", tools[0].Args[0].Name)
+	assert.Equal(t, "string", tools[0].Args[0].Type)
+	assert.True(t, tools[0].Args[0].Required)
+
+	// vehicle_info tool
+	assert.Equal(t, "vehicle_info", tools[1].Name)
+	assert.Equal(t, "Get vehicle info", tools[1].Description)
+	require.Len(t, tools[1].Args, 1)
+	assert.Equal(t, "tokenId", tools[1].Args[0].Name)
+	assert.Equal(t, "integer", tools[1].Args[0].Type)
+	assert.True(t, tools[1].Args[0].Required)
+}
+
+func TestPrefixApplied(t *testing.T) {
+	tools, err := parseSchema([]string{"testdata/basic.graphqls"}, "telemetry")
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+
+	assert.Equal(t, "telemetry_hello", tools[0].Name)
+	assert.Equal(t, "telemetry_vehicle_info", tools[1].Name)
+}
+
+func TestArgDescriptionFromDocString(t *testing.T) {
+	tools, err := parseSchema([]string{"testdata/docstrings.graphqls"}, "")
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	require.Len(t, tools[0].Args, 1)
+
+	assert.Equal(t, "The vehicle's NFT token ID", tools[0].Args[0].Description)
+}
+
+func TestArgDescriptionFallback(t *testing.T) {
+	tools, err := parseSchema([]string{"testdata/basic.graphqls"}, "")
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+
+	// hello tool's "name" arg has no doc string
+	assert.Equal(t, "name argument", tools[0].Args[0].Description)
+}
+
+func TestInvalidSelection(t *testing.T) {
+	_, err := parseSchema([]string{"testdata/invalid_selection.graphqls"}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonExistentField")
+}
+
+func TestGeneratedOutput(t *testing.T) {
+	tools, err := parseSchema([]string{"testdata/basic.graphqls"}, "test")
+	require.NoError(t, err)
+
+	output, err := generateGoFile("graph", tools)
+	require.NoError(t, err)
+
+	assert.True(t, strings.Contains(output, "package graph"))
+	assert.True(t, strings.Contains(output, `"github.com/DIMO-Network/server-garage/pkg/mcpserver"`))
+	assert.True(t, strings.Contains(output, "DO NOT EDIT"))
+	assert.True(t, strings.Contains(output, "test_hello"))
+	assert.True(t, strings.Contains(output, "test_vehicle_info"))
+}

--- a/cmd/mcpgen/main.go
+++ b/cmd/mcpgen/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	schemaDir := flag.String("schema", "", "directory containing .graphqls files")
+	prefix := flag.String("prefix", "", "tool name prefix")
+	out := flag.String("out", "", "output Go file path")
+	pkg := flag.String("package", "", "Go package name for generated file")
+	flag.Parse()
+
+	if *schemaDir == "" || *out == "" || *pkg == "" {
+		fmt.Fprintln(os.Stderr, "usage: mcpgen -schema <dir> -prefix <prefix> -out <file> -package <pkg>")
+		os.Exit(1)
+	}
+
+	// Collect .graphqls files
+	entries, err := os.ReadDir(*schemaDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading schema directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	var paths []string
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".graphqls" {
+			paths = append(paths, filepath.Join(*schemaDir, e.Name()))
+		}
+	}
+
+	if len(paths) == 0 {
+		fmt.Fprintln(os.Stderr, "no .graphqls files found in", *schemaDir)
+		os.Exit(1)
+	}
+
+	tools, err := parseSchema(paths, *prefix)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parsing schema: %v\n", err)
+		os.Exit(1)
+	}
+
+	output, err := generateGoFile(*pkg, tools)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "generating output: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "creating output directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(*out, []byte(output), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "writing output: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Generated %d tool(s) in %s\n", len(tools), *out)
+}

--- a/cmd/mcpgen/testdata/basic.graphqls
+++ b/cmd/mcpgen/testdata/basic.graphqls
@@ -1,0 +1,16 @@
+directive @mcpTool(name: String!, description: String!, selection: String!) on FIELD_DEFINITION
+
+type Query {
+  hello(name: String!): String!
+    @mcpTool(name: "hello", description: "Say hello to someone", selection: "")
+
+  vehicle(tokenId: Int!): Vehicle
+    @mcpTool(name: "vehicle_info", description: "Get vehicle info", selection: "tokenId owner")
+
+  noMcp: String!
+}
+
+type Vehicle {
+  tokenId: Int!
+  owner: String!
+}

--- a/cmd/mcpgen/testdata/docstrings.graphqls
+++ b/cmd/mcpgen/testdata/docstrings.graphqls
@@ -1,0 +1,13 @@
+directive @mcpTool(name: String!, description: String!, selection: String!) on FIELD_DEFINITION
+
+type Query {
+  vehicle(
+    """The vehicle's NFT token ID"""
+    tokenId: Int!
+  ): Vehicle
+    @mcpTool(name: "vehicle_info", description: "Get vehicle info", selection: "tokenId")
+}
+
+type Vehicle {
+  tokenId: Int!
+}

--- a/cmd/mcpgen/testdata/invalid_selection.graphqls
+++ b/cmd/mcpgen/testdata/invalid_selection.graphqls
@@ -1,0 +1,10 @@
+directive @mcpTool(name: String!, description: String!, selection: String!) on FIELD_DEFINITION
+
+type Query {
+  vehicle(tokenId: Int!): Vehicle
+    @mcpTool(name: "vehicle_info", description: "Get vehicle info", selection: "nonExistentField")
+}
+
+type Vehicle {
+  tokenId: Int!
+}

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,12 @@ require (
 	github.com/DIMO-Network/token-exchange-api v0.3.7
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/ethereum/go-ethereum v1.16.4
+	github.com/go-jose/go-jose/v3 v3.0.4
 	github.com/gofiber/contrib/jwt v1.1.2
 	github.com/gofiber/fiber/v2 v2.52.9
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/joho/godotenv v1.5.1
+	github.com/modelcontextprotocol/go-sdk v1.2.0
 	github.com/prometheus/client_golang v1.23.0
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
@@ -21,13 +24,13 @@ require (
 require (
 	github.com/DIMO-Network/shared v1.0.7 // indirect
 	github.com/MicahParks/keyfunc/v2 v2.1.0 // indirect
+	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
+	github.com/google/jsonschema-go v0.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
@@ -47,7 +50,9 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.65.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/crypto v0.43.0 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/caarlos0/env/v11 v11.3.1 h1:cArPWC15hWmEt+gWk7YBi7lEXTXCvpaSdCiZE2X5mCA=
@@ -24,6 +26,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/ethereum/go-ethereum v1.16.4 h1:H6dU0r2p/amA7cYg6zyG9Nt2JrKKH6oX2utfcqrSpkQ=
 github.com/ethereum/go-ethereum v1.16.4/go.mod h1:P7551slMFbjn2zOQaKrJShZVN/d8bGxp4/I6yZVlb5w=
 github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
@@ -40,6 +44,8 @@ github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArs
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
@@ -67,6 +73,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/modelcontextprotocol/go-sdk v1.2.0 h1:Y23co09300CEk8iZ/tMxIX1dVmKZkzoSBZOpJwUnc/s=
+github.com/modelcontextprotocol/go-sdk v1.2.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -114,6 +122,8 @@ github.com/vektah/gqlparser/v2 v2.5.30 h1:EqLwGAFLIzt1wpx1IPpY67DwUujF1OfzgEyDsL
 github.com/vektah/gqlparser/v2 v2.5.30/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
@@ -131,6 +141,8 @@ golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.45.0 h1:RLBg5JKixCy82FtLJpeNlVM0nrSqpCRYzVU1n8kj0tM=
 golang.org/x/net v0.45.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -164,6 +176,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+golang.org/x/tools v0.36.0 h1:kWS0uv/zsvHEle1LbV5LE8QujrxB3wfQyxHfhOk0Qkg=
+golang.org/x/tools v0.36.0/go.mod h1:WBDiHKJK8YgLHlcQPYQzNCkUxUypCaa5ZegCVutKm+s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/pkg/mcpserver/executor.go
+++ b/pkg/mcpserver/executor.go
@@ -1,0 +1,127 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// schemaCache caches the result of a GraphQL introspection query.
+type schemaCache struct {
+	exec   GraphQLExecutor
+	mu     sync.Mutex
+	done   bool
+	cached string
+}
+
+// getSchema returns the GraphQL schema via introspection. The result is cached
+// after the first successful call.
+func (s *schemaCache) getSchema(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.done {
+		return s.cached, nil
+	}
+
+	result, err := s.exec.Execute(ctx, introspectionQuery, nil)
+	if err != nil {
+		return "", fmt.Errorf("introspection query: %w", err)
+	}
+
+	s.cached = string(result)
+	s.done = true
+
+	return s.cached, nil
+}
+
+// introspectionQuery is the full introspection query used to fetch the schema.
+const introspectionQuery = `
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`

--- a/pkg/mcpserver/gqlgen.go
+++ b/pkg/mcpserver/gqlgen.go
@@ -1,0 +1,41 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/executor"
+)
+
+// gqlgenExecutor implements GraphQLExecutor using a gqlgen ExecutableSchema.
+type gqlgenExecutor struct {
+	exec *executor.Executor
+}
+
+// NewGQLGenExecutor returns a GraphQLExecutor backed by a gqlgen ExecutableSchema.
+func NewGQLGenExecutor(es graphql.ExecutableSchema) GraphQLExecutor {
+	return &gqlgenExecutor{
+		exec: executor.New(es),
+	}
+}
+
+// Execute runs a GraphQL query against the gqlgen schema.
+func (g *gqlgenExecutor) Execute(ctx context.Context, query string, variables map[string]any) ([]byte, error) {
+	params := &graphql.RawParams{
+		Query:     query,
+		Variables: variables,
+	}
+
+	opCtx, errs := g.exec.CreateOperationContext(ctx, params)
+	if errs != nil {
+		resp := g.exec.DispatchError(graphql.WithOperationContext(ctx, opCtx), errs)
+		return json.Marshal(resp)
+	}
+
+	ctx = graphql.WithOperationContext(ctx, opCtx)
+	handler, ctx := g.exec.DispatchOperation(ctx, opCtx)
+	resp := handler(ctx)
+
+	return json.Marshal(resp)
+}

--- a/pkg/mcpserver/mcpserver.go
+++ b/pkg/mcpserver/mcpserver.go
@@ -1,0 +1,73 @@
+package mcpserver
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rs/zerolog"
+)
+
+// GraphQLExecutor executes GraphQL operations and returns the JSON response.
+type GraphQLExecutor interface {
+	Execute(ctx context.Context, query string, variables map[string]any) ([]byte, error)
+}
+
+// ArgDefinition describes a single argument for a tool.
+type ArgDefinition struct {
+	Name        string
+	Type        string // "string", "integer", "number", "boolean", "object"
+	Description string
+	Required    bool
+}
+
+// ToolDefinition describes an MCP tool backed by a GraphQL query.
+type ToolDefinition struct {
+	Name        string
+	Description string
+	Args        []ArgDefinition
+	Query       string
+}
+
+// Option configures the MCP server.
+type Option func(*config)
+
+// config holds internal configuration for the MCP server.
+type config struct {
+	tools []ToolDefinition
+}
+
+// WithTools returns an Option that registers additional tool definitions.
+func WithTools(tools []ToolDefinition) Option {
+	return func(c *config) {
+		c.tools = append(c.tools, tools...)
+	}
+}
+
+// New creates an http.Handler that serves an MCP Streamable HTTP server.
+// It wraps a GraphQL executor and exposes registered tools as MCP tools.
+func New(exec GraphQLExecutor, serverName string, toolPrefix string, opts ...Option) http.Handler {
+	cfg := &config{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    serverName,
+		Version: "0.1.0",
+	}, nil)
+
+	cache := &schemaCache{exec: exec}
+
+	// Pre-warm the schema cache so the first MCP client doesn't pay introspection cost.
+	if _, err := cache.getSchema(context.Background()); err != nil {
+		zerolog.Ctx(context.Background()).Warn().Err(err).Msg("failed to pre-warm schema cache")
+	}
+
+	registerBuiltinTools(server, exec, cache, toolPrefix)
+	registerShortcutTools(server, exec, cfg.tools)
+
+	return mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+		return server
+	}, nil)
+}

--- a/pkg/mcpserver/mcpserver_test.go
+++ b/pkg/mcpserver/mcpserver_test.go
@@ -1,0 +1,300 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockExecutor implements GraphQLExecutor for testing.
+type mockExecutor struct {
+	fn func(ctx context.Context, query string, variables map[string]any) ([]byte, error)
+}
+
+func (m *mockExecutor) Execute(ctx context.Context, query string, variables map[string]any) ([]byte, error) {
+	return m.fn(ctx, query, variables)
+}
+
+func TestExecutorQuery(t *testing.T) {
+	expected := `{"data":{"vehicle":{"id":"123"}}}`
+	exec := &mockExecutor{
+		fn: func(ctx context.Context, query string, variables map[string]any) ([]byte, error) {
+			return []byte(expected), nil
+		},
+	}
+
+	result, err := exec.Execute(context.Background(), `{ vehicle { id } }`, nil)
+	require.NoError(t, err)
+	assert.JSONEq(t, expected, string(result))
+}
+
+type ctxKey string
+
+func TestExecutorContextPropagation(t *testing.T) {
+	key := ctxKey("user_id")
+	exec := &mockExecutor{
+		fn: func(ctx context.Context, query string, variables map[string]any) ([]byte, error) {
+			val := ctx.Value(key)
+			if val == nil {
+				return nil, fmt.Errorf("context value not propagated")
+			}
+			if val != "user-42" {
+				return nil, fmt.Errorf("unexpected context value: %v", val)
+			}
+			return []byte(`{"data":{}}`), nil
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), key, "user-42")
+	_, err := exec.Execute(ctx, `{ me { id } }`, nil)
+	require.NoError(t, err)
+}
+
+func TestExecutorError(t *testing.T) {
+	exec := &mockExecutor{
+		fn: func(ctx context.Context, query string, variables map[string]any) ([]byte, error) {
+			return nil, fmt.Errorf("execution failed")
+		},
+	}
+
+	_, err := exec.Execute(context.Background(), `{ fail }`, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "execution failed")
+}
+
+func TestGetSchema(t *testing.T) {
+	exec := &mockExecutor{
+		fn: func(ctx context.Context, query string, variables map[string]any) ([]byte, error) {
+			if strings.Contains(query, "__schema") {
+				return []byte(`{"data":{"__schema":{"types":[{"name":"Query"}]}}}`), nil
+			}
+			return nil, fmt.Errorf("unexpected query")
+		},
+	}
+
+	cache := &schemaCache{exec: exec}
+	schema, err := cache.getSchema(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, schema, "__schema")
+}
+
+func TestGetSchemaCaching(t *testing.T) {
+	var callCount atomic.Int32
+	exec := &mockExecutor{
+		fn: func(ctx context.Context, query string, variables map[string]any) ([]byte, error) {
+			callCount.Add(1)
+			return []byte(`{"data":{"__schema":{"types":[]}}}`), nil
+		},
+	}
+
+	cache := &schemaCache{exec: exec}
+
+	schema1, err := cache.getSchema(context.Background())
+	require.NoError(t, err)
+
+	schema2, err := cache.getSchema(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, schema1, schema2)
+	assert.Equal(t, int32(1), callCount.Load(), "executor should only be called once due to caching")
+}
+
+// mockGQLExecutor returns a GraphQLExecutor that handles introspection and echoes regular queries.
+func mockGQLExecutor() GraphQLExecutor {
+	return &mockExecutor{
+		fn: func(ctx context.Context, query string, variables map[string]any) ([]byte, error) {
+			if strings.Contains(query, "__schema") {
+				return []byte(`{"data":{"__schema":{"queryType":{"name":"Query"},"types":[{"name":"Query"},{"name":"Vehicle"}]}}}`), nil
+			}
+			resp := map[string]any{
+				"data": map[string]any{
+					"echoQuery":     query,
+					"echoVariables": variables,
+				},
+			}
+			return json.Marshal(resp)
+		},
+	}
+}
+
+func TestShortcutTool(t *testing.T) {
+	toolDef := ToolDefinition{
+		Name:        "get_vehicle",
+		Description: "Fetches a vehicle by token ID.",
+		Args: []ArgDefinition{
+			{Name: "tokenId", Type: "integer", Description: "The vehicle token ID", Required: true},
+		},
+		Query: `query GetVehicle($tokenId: Int!) { vehicle(tokenId: $tokenId) { id make model } }`,
+	}
+
+	mcpServer := mcp.NewServer(&mcp.Implementation{
+		Name:    "test-server",
+		Version: "0.1.0",
+	}, nil)
+
+	exec := mockGQLExecutor()
+	registerShortcutTools(mcpServer, exec, []ToolDefinition{toolDef})
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = mcpServer.Run(ctx, serverTransport)
+	}()
+
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "test-client",
+		Version: "0.1.0",
+	}, nil)
+
+	session, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "get_vehicle",
+		Arguments: map[string]any{
+			"tokenId": 42,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+
+	contentJSON, err := json.Marshal(result.Content[0])
+	require.NoError(t, err)
+	var textContent struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(contentJSON, &textContent))
+	assert.Equal(t, "text", textContent.Type)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &resp))
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, toolDef.Query, data["echoQuery"])
+
+	vars := data["echoVariables"].(map[string]any)
+	assert.Equal(t, float64(42), vars["tokenId"])
+}
+
+func TestMCPHandlerEndToEnd(t *testing.T) {
+	shortcutTool := ToolDefinition{
+		Name:        "get_vehicle",
+		Description: "Fetches a vehicle by token ID.",
+		Args: []ArgDefinition{
+			{Name: "tokenId", Type: "integer", Description: "The vehicle token ID", Required: true},
+		},
+		Query: `query GetVehicle($tokenId: Int!) { vehicle(tokenId: $tokenId) { id } }`,
+	}
+
+	mcpHandler := New(mockGQLExecutor(), "Test Server", "test", WithTools([]ToolDefinition{shortcutTool}))
+
+	ts := httptest.NewServer(mcpHandler)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:   ts.URL,
+		HTTPClient: ts.Client(),
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "test-client",
+		Version: "1.0",
+	}, nil)
+
+	session, err := client.Connect(ctx, transport, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	result, err := session.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	toolNames := make(map[string]bool)
+	for _, tool := range result.Tools {
+		toolNames[tool.Name] = true
+	}
+
+	assert.True(t, toolNames["test_get_schema"], "expected test_get_schema tool")
+	assert.True(t, toolNames["test_query"], "expected test_query tool")
+	assert.True(t, toolNames["get_vehicle"], "expected get_vehicle shortcut tool")
+
+	schemaResult, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "test_get_schema",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, schemaResult)
+	require.Len(t, schemaResult.Content, 1)
+
+	contentJSON, err := json.Marshal(schemaResult.Content[0])
+	require.NoError(t, err)
+	var textContent struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(contentJSON, &textContent))
+	assert.Equal(t, "text", textContent.Type)
+	assert.Contains(t, textContent.Text, "__schema")
+
+	queryResult, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "test_query",
+		Arguments: map[string]any{
+			"query": "{ vehicles { id } }",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, queryResult)
+	require.Len(t, queryResult.Content, 1)
+}
+
+func TestToolPrefixing(t *testing.T) {
+	mcpHandler := New(mockGQLExecutor(), "Prefixed Server", "myprefix")
+
+	ts := httptest.NewServer(mcpHandler)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:   ts.URL,
+		HTTPClient: ts.Client(),
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "test-client",
+		Version: "1.0",
+	}, nil)
+
+	session, err := client.Connect(ctx, transport, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	result, err := session.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	toolNames := make(map[string]bool)
+	for _, tool := range result.Tools {
+		toolNames[tool.Name] = true
+	}
+
+	assert.True(t, toolNames["myprefix_get_schema"], "expected myprefix_get_schema tool")
+	assert.True(t, toolNames["myprefix_query"], "expected myprefix_query tool")
+	assert.False(t, toolNames["test_get_schema"], "should not have test prefix")
+	assert.False(t, toolNames["test_query"], "should not have test prefix")
+}

--- a/pkg/mcpserver/metrics.go
+++ b/pkg/mcpserver/metrics.go
@@ -1,0 +1,24 @@
+package mcpserver
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	toolCallsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mcp_tool_calls_total",
+			Help: "Total number of MCP tool calls, categorized by tool and status.",
+		},
+		[]string{"tool", "status"},
+	)
+
+	toolDurationSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "mcp_tool_duration_seconds",
+			Help: "Duration of MCP tool calls in seconds.",
+		},
+		[]string{"tool"},
+	)
+)

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -1,0 +1,137 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rs/zerolog"
+)
+
+// queryInput is the input for the query tool.
+type queryInput struct {
+	Query     string         `json:"query" jsonschema:"GraphQL query string"`
+	Variables map[string]any `json:"variables,omitempty" jsonschema:"GraphQL variables"`
+}
+
+// instrumentTool logs and records metrics for a tool call.
+func instrumentTool(ctx context.Context, toolName string, fn func() error) {
+	start := time.Now()
+	err := fn()
+	duration := time.Since(start)
+	logger := zerolog.Ctx(ctx)
+	status := "success"
+	if err != nil {
+		status = "error"
+		logger.Error().Err(err).Str("tool", toolName).Dur("duration", duration).Msg("tool call failed")
+	} else {
+		logger.Info().Str("tool", toolName).Dur("duration", duration).Msg("tool call succeeded")
+	}
+	toolCallsTotal.WithLabelValues(toolName, status).Inc()
+	toolDurationSeconds.WithLabelValues(toolName).Observe(duration.Seconds())
+}
+
+// registerBuiltinTools registers the built-in tools (get_schema, query) on the server.
+func registerBuiltinTools(server *mcp.Server, exec GraphQLExecutor, cache *schemaCache, toolPrefix string) {
+	schemaToolName := toolPrefix + "_get_schema"
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        schemaToolName,
+		Description: "Returns the GraphQL schema via introspection. Use this to understand available types and fields before constructing queries.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		var schema string
+		var toolErr error
+		instrumentTool(ctx, schemaToolName, func() error {
+			schema, toolErr = cache.getSchema(ctx)
+			return toolErr
+		})
+		if toolErr != nil {
+			return nil, nil, toolErr
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: schema},
+			},
+		}, nil, nil
+	})
+
+	queryToolName := toolPrefix + "_query"
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        queryToolName,
+		Description: "Executes an arbitrary GraphQL query against the API.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input queryInput) (*mcp.CallToolResult, any, error) {
+		var result []byte
+		var toolErr error
+		instrumentTool(ctx, queryToolName, func() error {
+			result, toolErr = exec.Execute(ctx, input.Query, input.Variables)
+			return toolErr
+		})
+		if toolErr != nil {
+			return nil, nil, toolErr
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: string(result)},
+			},
+		}, nil, nil
+	})
+}
+
+// buildInputSchema constructs a ToolInputSchema from ArgDefinitions.
+func buildInputSchema(args []ArgDefinition) map[string]any {
+	properties := make(map[string]any)
+	var required []string
+	for _, arg := range args {
+		properties[arg.Name] = map[string]any{
+			"type":        arg.Type,
+			"description": arg.Description,
+		}
+		if arg.Required {
+			required = append(required, arg.Name)
+		}
+	}
+	schema := map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+// registerShortcutTools registers shortcut tools derived from ToolDefinitions.
+func registerShortcutTools(server *mcp.Server, exec GraphQLExecutor, tools []ToolDefinition) {
+	for _, tool := range tools {
+		inputSchema := buildInputSchema(tool.Args)
+
+		server.AddTool(&mcp.Tool{
+			Name:        tool.Name,
+			Description: tool.Description,
+			InputSchema: inputSchema,
+		}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var args map[string]any
+			if req.Params.Arguments != nil {
+				if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+					return nil, fmt.Errorf("unmarshal arguments: %w", err)
+				}
+			}
+
+			var result []byte
+			var toolErr error
+			instrumentTool(ctx, tool.Name, func() error {
+				result, toolErr = exec.Execute(ctx, tool.Query, args)
+				return toolErr
+			})
+			if toolErr != nil {
+				return nil, toolErr
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: string(result)},
+				},
+			}, nil
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a reusable MCP (Model Context Protocol) server package and a companion codegen tool that any gqlgen-based DIMO service can import to serve MCP alongside its existing GraphQL API.

### New packages

**`pkg/mcpserver`** — Wraps any gqlgen `http.Handler` as an MCP Streamable HTTP server using the official `modelcontextprotocol/go-sdk v1.2.0`.

- Two built-in tools per service: `{prefix}_get_schema` (cached introspection) and `{prefix}_query` (arbitrary GraphQL execution)
- Shortcut tools for common queries, registered via `WithTools()` from codegen output
- Internal execution via `httptest` with full context propagation — JWT claims and other context values flow through to gqlgen directives unchanged
- Prometheus metrics: `mcp_tool_calls_total{tool,status}` counter + `mcp_tool_duration_seconds{tool}` histogram
- Logging via `zerolog.Ctx(ctx)` (follows existing server-garage patterns)
- Schema cache pre-warmed at startup
- **No auth in the library** — each service wraps the handler with its own middleware

**`cmd/mcpgen`** — Code generation tool that reads `@mcpTool` directives from `.graphqls` schema files and generates typed Go tool definitions.

- Reads `name`, `description`, and `selection` from directive args
- Validates selection fields against the schema at build time
- Extracts argument descriptions from GraphQL doc strings with fallback
- Maps GraphQL types to JSON Schema types (including custom scalars and enums → `"string"`)
- Outputs a `var MCPTools = []mcpserver.ToolDefinition{...}` Go file

### Usage

```go
// In your service's main.go:
mcpHandler := mcpserver.New(gqlHandler, "DIMO Identity", "identity",
    mcpserver.WithTools(graph.MCPTools), // from codegen
)
mux.Handle("/mcp", mcpHandler)
```

```bash
# Generate tool definitions from schema:
mcpgen -schema ./schema/ -prefix identity -out ./graph/mcp_tools_gen.go -package graph
```

### Design spec
`docs/superpowers/specs/2026-03-24-mcp-server-library-design.md`

## Test plan

- [x] 8 unit tests for `pkg/mcpserver` (executor, context propagation, caching, tool registration, end-to-end MCP transport, tool prefixing)
- [x] 6 unit tests for `cmd/mcpgen` (directive parsing, prefix, docstrings, fallback descriptions, invalid selection, generated output)
- [x] Full repo test suite passes (14 tests total)
- [ ] Integration tested via identity-api and telemetry-api PRs