### PR TITLE
fix(mcpserver): coerce JSON float64 ints to int64 for shortcut tool args

### DIFF
--- a/pkg/mcpserver/mcpserver_test.go
+++ b/pkg/mcpserver/mcpserver_test.go
@@ -761,3 +761,40 @@ func TestWithLoggerOption(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "tool call succeeded")
 }
+
+func TestCoerceArgTypes(t *testing.T) {
+	defs := map[string]ArgDefinition{
+		"tokenId":  {Name: "tokenId", Type: "integer"},
+		"name":     {Name: "name", Type: "string"},
+		"ids":      {Name: "ids", Type: "array", ItemsType: "integer"},
+		"tags":     {Name: "tags", Type: "array", ItemsType: "string"},
+		"nullable": {Name: "nullable", Type: "integer"},
+	}
+
+	args := map[string]any{
+		"tokenId":  float64(3),
+		"name":     "foo",
+		"ids":      []any{float64(1), float64(2), float64(3)},
+		"tags":     []any{"a", "b"},
+		"nullable": nil,
+		"unknown":  float64(99),
+	}
+
+	coerceArgTypes(args, defs)
+
+	assert.Equal(t, int64(3), args["tokenId"])
+	assert.Equal(t, "foo", args["name"])
+	assert.Equal(t, []any{int64(1), int64(2), int64(3)}, args["ids"])
+	assert.Equal(t, []any{"a", "b"}, args["tags"])
+	assert.Nil(t, args["nullable"])
+	assert.Equal(t, float64(99), args["unknown"])
+}
+
+func TestCoerceArgTypesPreservesExistingInts(t *testing.T) {
+	defs := map[string]ArgDefinition{
+		"tokenId": {Name: "tokenId", Type: "integer"},
+	}
+	args := map[string]any{"tokenId": int64(7)}
+	coerceArgTypes(args, defs)
+	assert.Equal(t, int64(7), args["tokenId"])
+}

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -149,6 +149,10 @@ func buildInputSchema(args []ArgDefinition) map[string]any {
 func registerShortcutTools(server *mcp.Server, exec GraphQLExecutor, tools []ToolDefinition, logger *slog.Logger) {
 	for _, tool := range tools {
 		inputSchema := buildInputSchema(tool.Args)
+		argDefs := make(map[string]ArgDefinition, len(tool.Args))
+		for _, a := range tool.Args {
+			argDefs[a.Name] = a
+		}
 
 		mcp.AddTool(server, &mcp.Tool{
 			Name:        tool.Name,
@@ -156,7 +160,40 @@ func registerShortcutTools(server *mcp.Server, exec GraphQLExecutor, tools []Too
 			InputSchema: inputSchema,
 			Annotations: tool.Annotations,
 		}, func(ctx context.Context, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			coerceArgTypes(args, argDefs)
 			return executeTool(ctx, tool.Name, exec, tool.Query, args, logger)
 		})
+	}
+}
+
+// coerceArgTypes normalizes JSON-decoded argument values to the types
+// gqlgen's scalar unmarshallers expect. JSON numbers arrive as float64 via
+// map[string]any, which gqlgen's Int unmarshaller rejects ("float64 is not
+// an int"); integer-typed args are converted to int64.
+func coerceArgTypes(args map[string]any, argDefs map[string]ArgDefinition) {
+	for name, v := range args {
+		def, ok := argDefs[name]
+		if !ok {
+			continue
+		}
+		switch def.Type {
+		case "integer":
+			if f, isFloat := v.(float64); isFloat {
+				args[name] = int64(f)
+			}
+		case "array":
+			if def.ItemsType != "integer" {
+				continue
+			}
+			list, isList := v.([]any)
+			if !isList {
+				continue
+			}
+			for i, item := range list {
+				if f, isFloat := item.(float64); isFloat {
+					list[i] = int64(f)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes \`float64 is not an int\` failures on every MCP shortcut tool that takes an integer arg (e.g. \`identity_get_vehicle\` with \`tokenId: 3\`).
- MCP SDK JSON-decodes number args into \`float64\` inside \`map[string]any\`; gqlgen's \`Int!\` scalar unmarshaller rejects \`float64\`.
- Coerce arg values to \`int64\` in \`registerShortcutTools\` based on \`ArgDefinition.Type == "integer"\`, recursing into array items when \`ItemsType == "integer"\`.

## Test plan
- [x] Added \`TestCoerceArgTypes\` + \`TestCoerceArgTypesPreservesExistingInts\`
- [x] \`go test ./...\` green
- [x] \`make lint\` green
- [ ] Cascade dep bump to identity-api / telemetry-api / fetch-api after merge + tag