### PR TITLE
feat(mcpgen,mcpserver): templated @mcpTool selections

### DIFF
--- a/cmd/mcpgen/condensed.go
+++ b/cmd/mcpgen/condensed.go
@@ -212,13 +212,19 @@ func extractTools(schema *ast.Schema, prefix string) ([]mcpserver.ToolDefinition
 		}
 		description := descArg.Value.Raw
 		selection := selArg.Value.Raw
+		isTemplated := isTemplatedSelection(selection)
 
 		readOnly := true // default
 		if readOnlyArg := dir.Arguments.ForName("readOnly"); readOnlyArg != nil {
 			readOnly = readOnlyArg.Value.Raw == "true"
 		}
 
-		if selection != "" {
+		// Only validate selections that are plain text. Templated selections
+		// can't be checked here because the rendered field names depend on
+		// per-call argument values; a bad template is rejected by mcpserver
+		// at registration time and bad rendered GraphQL is rejected by the
+		// executor at call time.
+		if selection != "" && !isTemplated {
 			returnTypeName := namedType(field.Type)
 			returnType := schema.Types[returnTypeName]
 			if returnType == nil {
@@ -250,7 +256,13 @@ func extractTools(schema *ast.Schema, prefix string) ([]mcpserver.ToolDefinition
 			})
 		}
 
-		query := buildQueryString(field, selection)
+		selectionTemplate := ""
+		querySelection := selection
+		if isTemplated {
+			selectionTemplate = selection
+			querySelection = mcpserver.SelectionPlaceholder
+		}
+		query := buildQueryString(field, querySelection)
 
 		var annotations *mcp.ToolAnnotations
 		if readOnly {
@@ -264,11 +276,12 @@ func extractTools(schema *ast.Schema, prefix string) ([]mcpserver.ToolDefinition
 		}
 
 		tools = append(tools, mcpserver.ToolDefinition{
-			Name:        toolName,
-			Description: description,
-			Args:        args,
-			Query:       query,
-			Annotations: annotations,
+			Name:              toolName,
+			Description:       description,
+			Args:              args,
+			Query:             query,
+			SelectionTemplate: selectionTemplate,
+			Annotations:       annotations,
 		})
 	}
 

--- a/cmd/mcpgen/generate.go
+++ b/cmd/mcpgen/generate.go
@@ -58,6 +58,13 @@ func buildQueryString(field *ast.FieldDefinition, selection string) string {
 	return sb.String()
 }
 
+// isTemplatedSelection reports whether a selection string contains Go
+// text/template action delimiters. When true, mcpgen emits it as a
+// SelectionTemplate rendered per call rather than a static selection set.
+func isTemplatedSelection(selection string) bool {
+	return strings.Contains(selection, "{{")
+}
+
 // validateSelection checks that top-level field names in the selection exist on the type.
 func validateSelection(selection string, typeDef *ast.Definition) error {
 	fields := extractTopLevelFields(selection)
@@ -236,6 +243,9 @@ var MCPTools = []mcpserver.ToolDefinition{
 		{{- end}}
 		},
 		Query: {{printf "%q" .Query}},
+		{{- if .SelectionTemplate}}
+		SelectionTemplate: {{printf "%q" .SelectionTemplate}},
+		{{- end}}
 		{{- if .Annotations}}
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint:    {{.Annotations.ReadOnlyHint}},

--- a/cmd/mcpgen/generate_test.go
+++ b/cmd/mcpgen/generate_test.go
@@ -217,6 +217,25 @@ func TestGeneratedCodeWithAnnotationsCompiles(t *testing.T) {
 	assert.Contains(t, output, "boolPtr")
 }
 
+func TestTemplatedSelection(t *testing.T) {
+	tools := loadTools(t, []string{"testdata/templated_selection.graphqls"}, "")
+	require.Len(t, tools, 1)
+
+	tool := tools[0]
+	assert.Equal(t, "get_signals", tool.Name)
+	assert.Equal(t, "timestamp {{range .signalRequests}} {{.name}}(agg: {{.agg}}) {{end}}", tool.SelectionTemplate)
+	assert.Contains(t, tool.Query, "__MCPGEN_SELECTION__", "Query should carry the selection placeholder")
+	assert.NotContains(t, tool.Query, "{{", "Query should not contain the raw template")
+}
+
+func TestTemplatedSelectionGeneratedOutput(t *testing.T) {
+	tools := loadTools(t, []string{"testdata/templated_selection.graphqls"}, "test")
+	output, err := generateGoFile("graph", tools, "")
+	require.NoError(t, err)
+	assert.Contains(t, output, "SelectionTemplate:")
+	assert.Contains(t, output, "__MCPGEN_SELECTION__")
+}
+
 func TestMapGraphQLTypeAllScalars(t *testing.T) {
 	tools := loadTools(t, []string{"testdata/all_types.graphqls"}, "")
 	require.Len(t, tools, 1)

--- a/cmd/mcpgen/testdata/templated_selection.graphqls
+++ b/cmd/mcpgen/testdata/templated_selection.graphqls
@@ -1,0 +1,21 @@
+directive @mcpTool(name: String!, description: String!, selection: String!, readOnly: Boolean = true) on FIELD_DEFINITION
+
+type Query {
+  signals(tokenId: Int!, signalRequests: [SignalRequest!]!): [Bucket!]
+    @mcpTool(
+      name: "get_signals"
+      description: "Aggregated signals with dynamic per-field selection"
+      selection: "timestamp {{range .signalRequests}} {{.name}}(agg: {{.agg}}) {{end}}"
+    )
+}
+
+type Bucket {
+  timestamp: String!
+  speed: Float
+  rpm: Float
+}
+
+input SignalRequest {
+  name: String!
+  agg: String!
+}

--- a/pkg/mcpserver/mcpserver.go
+++ b/pkg/mcpserver/mcpserver.go
@@ -25,13 +25,26 @@ type ArgDefinition struct {
 	EnumValues  []string // Allowed values for enum types
 }
 
+// SelectionPlaceholder is the marker mcpgen inserts into Query where a
+// per-call rendering of SelectionTemplate should be spliced in before
+// the query is executed.
+const SelectionPlaceholder = "__MCPGEN_SELECTION__"
+
 // ToolDefinition describes an MCP tool backed by a GraphQL query.
+//
+// When SelectionTemplate is empty, Query is executed as-is. When it is set,
+// mcpserver parses it once as a Go text/template at registration time and, on
+// each call, renders the template with the call's argument map and replaces
+// the first occurrence of SelectionPlaceholder in Query with the result.
+// mcpgen emits SelectionTemplate automatically when the @mcpTool `selection`
+// argument contains template markers (`{{` / `}}`).
 type ToolDefinition struct {
-	Name        string
-	Description string
-	Args        []ArgDefinition
-	Query       string
-	Annotations *mcp.ToolAnnotations
+	Name              string
+	Description       string
+	Args              []ArgDefinition
+	Query             string
+	SelectionTemplate string
+	Annotations       *mcp.ToolAnnotations
 }
 
 // Option configures the MCP server.
@@ -123,7 +136,9 @@ func New(exec GraphQLExecutor, serverName string, version string, toolPrefix str
 	})
 
 	registerBuiltinTools(server, exec, cfg.condensedSchema, toolPrefix, cfg.maxQuerySize, cfg.logger)
-	registerShortcutTools(server, exec, cfg.tools, cfg.logger)
+	if err := registerShortcutTools(server, exec, cfg.tools, cfg.logger); err != nil {
+		return nil, err
+	}
 
 	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return server

--- a/pkg/mcpserver/mcpserver_test.go
+++ b/pkg/mcpserver/mcpserver_test.go
@@ -106,7 +106,7 @@ func TestShortcutTool(t *testing.T) {
 	}, nil)
 
 	exec := mockGQLExecutor()
-	registerShortcutTools(mcpServer, exec, []ToolDefinition{toolDef}, nil)
+	require.NoError(t, registerShortcutTools(mcpServer, exec, []ToolDefinition{toolDef}, nil))
 
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
 
@@ -599,7 +599,7 @@ func TestShortcutToolUnexpectedArgs(t *testing.T) {
 	}
 
 	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	registerShortcutTools(mcpServer, mockGQLExecutor(), []ToolDefinition{tool}, nil)
+	require.NoError(t, registerShortcutTools(mcpServer, mockGQLExecutor(), []ToolDefinition{tool}, nil))
 
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
 	ctx := context.Background()
@@ -647,7 +647,7 @@ func TestMultipleShortcutToolsDispatch(t *testing.T) {
 
 	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
 	exec := mockGQLExecutor()
-	registerShortcutTools(mcpServer, exec, tools, nil)
+	require.NoError(t, registerShortcutTools(mcpServer, exec, tools, nil))
 
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
 	ctx := context.Background()
@@ -688,6 +688,81 @@ func TestMultipleShortcutToolsDispatch(t *testing.T) {
 			assert.Equal(t, tool.Query, data["echoQuery"], "tool %s dispatched wrong query", tool.Name)
 		})
 	}
+}
+
+func TestSelectionTemplateRendering(t *testing.T) {
+	var capturedQuery string
+	exec := &mockExecutor{
+		fn: func(ctx context.Context, query string, variables map[string]any) ([]byte, error) {
+			capturedQuery = query
+			return []byte(`{"data":{}}`), nil
+		},
+	}
+
+	tool := ToolDefinition{
+		Name:        "get_signals",
+		Description: "Aggregated signals with dynamic selection",
+		Args: []ArgDefinition{
+			{Name: "tokenId", Type: "integer", Required: true},
+			{Name: "signalRequests", Type: "array", ItemsType: "object", Required: true},
+		},
+		Query:             `query($tokenId: Int!, $signalRequests: [SignalRequest!]!) { signals(tokenId: $tokenId, signalRequests: $signalRequests) { __MCPGEN_SELECTION__ } }`,
+		SelectionTemplate: "timestamp{{range .signalRequests}} {{.name}}(agg: {{.agg}}){{end}}",
+	}
+
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
+	require.NoError(t, registerShortcutTools(mcpServer, exec, []ToolDefinition{tool}, nil))
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = mcpServer.Run(ctx, serverTransport) }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.1.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	_, err = session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "get_signals",
+		Arguments: map[string]any{
+			"tokenId": 42,
+			"signalRequests": []any{
+				map[string]any{"name": "speed", "agg": "AVG"},
+				map[string]any{"name": "rpm", "agg": "MAX"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, capturedQuery, "timestamp speed(agg: AVG) rpm(agg: MAX)")
+	assert.NotContains(t, capturedQuery, SelectionPlaceholder, "placeholder should have been substituted")
+	assert.NotContains(t, capturedQuery, "{{", "template markers should not leak into executed query")
+}
+
+func TestSelectionTemplateInvalidRejectedAtRegistration(t *testing.T) {
+	tool := ToolDefinition{
+		Name:              "bad_tool",
+		Description:       "Bad template",
+		Query:             `{ foo __MCPGEN_SELECTION__ }`,
+		SelectionTemplate: "{{ range .items", // missing closing braces
+	}
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
+	err := registerShortcutTools(mcpServer, mockGQLExecutor(), []ToolDefinition{tool}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad_tool")
+}
+
+func TestSelectionTemplateMissingPlaceholderRejected(t *testing.T) {
+	tool := ToolDefinition{
+		Name:              "no_placeholder",
+		Description:       "Template with no placeholder in Query",
+		Query:             `{ foo }`,
+		SelectionTemplate: "bar",
+	}
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
+	err := registerShortcutTools(mcpServer, mockGQLExecutor(), []ToolDefinition{tool}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), SelectionPlaceholder)
 }
 
 func TestTokenVerifierContextPropagation(t *testing.T) {

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
+	"text/template"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -146,12 +148,25 @@ func buildInputSchema(args []ArgDefinition) map[string]any {
 }
 
 // registerShortcutTools registers shortcut tools derived from ToolDefinitions.
-func registerShortcutTools(server *mcp.Server, exec GraphQLExecutor, tools []ToolDefinition, logger *slog.Logger) {
+// Returns an error if any tool's SelectionTemplate fails to parse.
+func registerShortcutTools(server *mcp.Server, exec GraphQLExecutor, tools []ToolDefinition, logger *slog.Logger) error {
 	for _, tool := range tools {
 		inputSchema := buildInputSchema(tool.Args)
 		argDefs := make(map[string]ArgDefinition, len(tool.Args))
 		for _, a := range tool.Args {
 			argDefs[a.Name] = a
+		}
+
+		var selTmpl *template.Template
+		if tool.SelectionTemplate != "" {
+			tmpl, err := template.New(tool.Name).Parse(tool.SelectionTemplate)
+			if err != nil {
+				return fmt.Errorf("mcpserver: parse SelectionTemplate for tool %q: %w", tool.Name, err)
+			}
+			if !strings.Contains(tool.Query, SelectionPlaceholder) {
+				return fmt.Errorf("mcpserver: tool %q has SelectionTemplate but Query is missing placeholder %q", tool.Name, SelectionPlaceholder)
+			}
+			selTmpl = tmpl
 		}
 
 		mcp.AddTool(server, &mcp.Tool{
@@ -161,9 +176,21 @@ func registerShortcutTools(server *mcp.Server, exec GraphQLExecutor, tools []Too
 			Annotations: tool.Annotations,
 		}, func(ctx context.Context, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			coerceArgTypes(args, argDefs)
-			return executeTool(ctx, tool.Name, exec, tool.Query, args, logger)
+			query := tool.Query
+			if selTmpl != nil {
+				var buf strings.Builder
+				if err := selTmpl.Execute(&buf, args); err != nil {
+					return &mcp.CallToolResult{
+						Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("failed to render selection template: %s", err.Error())}},
+						IsError: true,
+					}, nil, nil
+				}
+				query = strings.Replace(tool.Query, SelectionPlaceholder, buf.String(), 1)
+			}
+			return executeTool(ctx, tool.Name, exec, query, args, logger)
 		})
 	}
+	return nil
 }
 
 // coerceArgTypes normalizes JSON-decoded argument values to the types


### PR DESCRIPTION
## Summary

- `@mcpTool(selection: "...")` now accepts Go `text/template` syntax. The rendered selection is spliced into the query at call time with the call's argument map as template data.
- Non-templated selections keep taking the existing fast path; no breaking change for any existing tool.
- Adds `ToolDefinition.SelectionTemplate` and the `SelectionPlaceholder` marker that mcpgen puts into `Query` when the selection is templated.

## Why

Static selection strings cannot express selection sets that depend on per-call argument values. For consumers like telemetry-api's `signals` query, where each `{name, agg}` pair needs to become its own sub-field `name(agg: AGG)`, the current shortcut tool's selection `timestamp` returns empty buckets and forces models to stuff signal names into unrelated arguments like `filter`. Fixing this at the mcpgen layer means every consumer repo gets dynamic selections by annotation alone — no schema reshaping, no resolver rewrites, no breaking changes in consumer schemas.

## Example

```graphql
signals(tokenId: Int!, signalRequests: [SignalRequest!]!): [Bucket!]
  @mcpTool(
    name: "get_signals"
    description: "..."
    selection: "timestamp {{range .signalRequests}} {{.name}}(agg: {{.agg}}) {{end}}"
  )
```

A call with `signalRequests: [{name: \"speed\", agg: AVG}, {name: \"rpm\", agg: MAX}]` renders to:

```graphql
query(...) { signals(...) { timestamp  speed(agg: AVG)  rpm(agg: MAX)  } }
```

## Changes

- `pkg/mcpserver/mcpserver.go`: `ToolDefinition.SelectionTemplate`, exported `SelectionPlaceholder`, error propagation from `registerShortcutTools` through `New`.
- `pkg/mcpserver/tools.go`: parse each `SelectionTemplate` once at registration; render + splice per call; fail-fast on bad templates or missing placeholder.
- `cmd/mcpgen/condensed.go`: detect `{{` in selection; emit `SelectionPlaceholder` in the generated `Query`; skip static validation for templated selections.
- `cmd/mcpgen/generate.go`: `isTemplatedSelection` helper; Go file template emits `SelectionTemplate` when non-empty.
- Tests:
  - `cmd/mcpgen`: `TestTemplatedSelection`, `TestTemplatedSelectionGeneratedOutput` + `testdata/templated_selection.graphqls`.
  - `pkg/mcpserver`: `TestSelectionTemplateRendering`, `TestSelectionTemplateInvalidRejectedAtRegistration`, `TestSelectionTemplateMissingPlaceholderRejected`.

## Test plan

- [x] `make lint` clean
- [x] `go test ./...` (all existing + new tests pass)
- [ ] Bump server-garage in telemetry-api, convert the `signals` / `signalsLatest` `@mcpTool` annotations to templated selections, confirm the `/mcp` tools return correctly-shaped data end-to-end